### PR TITLE
Fix user disablement check to include nologin

### DIFF
--- a/exercises/lesson_05/breach/data/tests/03_expired.sh
+++ b/exercises/lesson_05/breach/data/tests/03_expired.sh
@@ -2,12 +2,16 @@
 
 . data/tests/util.sh
 
-test_account_expired()
+test_account_disabled()
 {
 
-    if [[ $(getent passwd test) ]] &&
-       [[ x"$(getent shadow test | cut -d : -f 8)" == "x0" ]]; then
-        return 0
+    if [[ $(getent passwd test) ]]; then
+        if [[ $(getent passwd test | cut -d : -f 7) =~ nologin ]] ||
+           [[ x"$(getent shadow test | cut -d : -f 8)" == "x0" ]]; then
+            return 0
+        else
+            return 1
+        fi
     else
         return 1
     fi
@@ -15,5 +19,5 @@ test_account_expired()
 
 
 RES=0
-run test_account_expired "check for account preventive measures" || RES=1
+run test_account_disabled "check for account preventive measures" || RES=1
 exit $RES


### PR DESCRIPTION
Currently only 'chage' is considered, but adding '/sbin/nologin' should
also be considered a correct solution.