### PR TITLE
exercises: 05: Improve user disablement check about nologin

### DIFF
--- a/exercises/lesson_05/breach/data/tests/03_expired.sh
+++ b/exercises/lesson_05/breach/data/tests/03_expired.sh
@@ -6,7 +6,9 @@ test_account_disabled()
 {
 
     if [[ $(getent passwd test) ]]; then
-        if [[ $(getent passwd test | cut -d : -f 7) =~ nologin ]] ||
+        if (getent passwd test | \
+            cut -d : -f 7 | \
+            grep -E "^(/usr)?/sbin/nologin$" &>/dev/null) ||
            [[ x"$(getent shadow test | cut -d : -f 8)" == "x0" ]]; then
             return 0
         else


### PR DESCRIPTION
The current check is a bit fragile and should check an exact path -
either /usr/sbin/nologin or /sbin/nologin.